### PR TITLE
Added Support to Upload Policies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "aadb2c",
     "displayName": "Azure AD B2C (Beta)",
     "description": "Azure AD B2C custom policy extension",
-    "version": "1.2.15",
+    "version": "1.3.00",
     "publisher": "AzureADB2CTools",
     "engines": {
         "vscode": "^1.22.0"
@@ -43,6 +43,10 @@
             {
                 "command": "extension.insertApplicationInsights",
                 "title": "B2C Add Application Insights (debug mode)"
+            },
+            {
+                "command": "extension.policy.upload",
+                "title": "B2C Policy Upload"
             }
         ],
         "keybindings": [
@@ -102,6 +106,10 @@
         "xmldom": "^0.1.27"
     },
     "dependencies": {
+        "adal-node": "^0.1.28",
+        "request": "^2.87.0",
+        "request-promise": "^4.2.2",
+        "web-request": "^1.0.7",
         "xmldom": "^0.1.27"
     }
 }

--- a/src/B2CUtils.ts
+++ b/src/B2CUtils.ts
@@ -1,0 +1,117 @@
+// Adding ADAL for Policy Upload
+import * as adal from 'adal-node';
+import { window } from 'vscode';
+import * as vscode from 'vscode';
+import Consts from './Consts';
+
+interface PolicyInfoObj {
+    PolicyId: string,
+    TenantId: string;
+}
+
+export default class B2CUtils {
+
+
+    // Gets the Tenant ID and Policy ID from the Open Document
+    static getPolicyInfo() : PolicyInfoObj
+    {
+        var DOMParser = require('xmldom').DOMParser;
+        let editor = window.activeTextEditor;
+        var xmldata = "";
+        if (editor) {
+            let doc = editor.document;
+            xmldata = doc.getText();
+        }
+
+        try {
+            
+        var xmlDoc = new DOMParser().parseFromString(xmldata);
+        var Polid = xmlDoc.getElementsByTagName("TrustFrameworkPolicy")[0].getAttribute("PolicyId")
+        var tenantID = xmlDoc.getElementsByTagName("TrustFrameworkPolicy")[0].getAttribute("TenantId")
+        } catch (error) {
+                vscode.window.showErrorMessage("Error retrieveing PolicyId and TenantId from Policy File. Please ensure the file being uploaded is a valid B2C Policy file.");
+                throw Error;
+        }
+
+        var rtnobj = {
+            PolicyId: Polid ,
+            TenantId: tenantID
+        };
+
+        return rtnobj;
+    }
+
+
+    static getB2CAPIClientID(context: vscode.ExtensionContext ) {
+
+        var clientID  = "";
+        if(!context.globalState.get("ClientId"))
+        {
+            vscode.window.showInputBox({ prompt: "You do not have a clientID set Please enter one:" })
+                .then(result => {
+                    if (!result)
+                        return Promise.reject('user cancelled');
+        
+                        clientID = result;
+                        context.globalState.update("ClientId",clientID)
+                });
+        }
+        else{
+            clientID =  "" + context.globalState.get("ClientId");
+        }
+        return clientID;
+    }
+
+    static async uploadpolicy(tokenResponse: adal.TokenResponse, PolicyId: string) {
+        var tr = tokenResponse as adal.TokenResponse;
+        var at = tr.accessToken;
+        console.log(tr.accessToken);
+    
+        var docContent = "";
+        console.log(" upload policy");
+        let editor = window.activeTextEditor;
+        if (editor) {
+            let doc = editor.document;
+            docContent = doc.getText();
+    
+        }
+    
+             
+        var rp = require('request-promise');
+    
+        var bearertoken = "Bearer " + at;
+    
+        const options = {
+          method: "PUT",
+          uri: Consts.B2CGraphEndpoint + PolicyId + "/$value",
+          headers: {
+            "Authorization": bearertoken,
+            "Content-Type": "application/xml"
+          },
+          body: docContent ,
+          json: false
+        };
+        
+                               
+         vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: "Uploading Policy (" + PolicyId + ")...",
+            cancellable: true
+        },
+        async (progress) => {await rp(options)
+          .then((r: any) => {
+                console.error("Upload success.")
+                vscode.window.showInformationMessage("Upload success",)
+            })
+           .catch((err: any) => {
+                var respErr  = JSON.parse(err.error);
+                console.error(err);
+                console.error("Upload failed: " + respErr.error.message)
+                vscode.window.showErrorMessage(respErr.error.message);
+           })
+           
+        });
+    }
+    
+
+}

--- a/src/Consts.ts
+++ b/src/Consts.ts
@@ -602,7 +602,11 @@ export default class Consts {
         '\t	<DataType>long</DataType>\r\n' +
         '\t	<AdminHelpText>Add help text here</AdminHelpText>\r\n' +
         '\t	<UserHelpText>Add help text here</UserHelpText>\r\n' +
-        '\t</ClaimType>\r\n';}
+        '\t</ClaimType>\r\n';
 
+        
+        static ADALresource: string ="https://graph.microsoft.com"; 
+        static ADALauthURLPrefix="https://login.microsoftonline.com/"; 
+        static B2CGraphEndpoint="https://graph.microsoft.com/testcpimtf/trustFrameworkPolicies/";
 
-
+    }


### PR DESCRIPTION
Yoel,

This Pull Requests contains the function "B2C Policy Upload" which allows you to upload the policy to B2C.

Requirement: Your tenant must be enabled for this feature.

Phil